### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,7 @@ find_package(Threads
 
 # TODO(gocarlos): we should also depend on boost beast here, conan not ready yet
 find_package(Boost
-             REQUIRED
-             COMPONENTS system)
+             REQUIRED)
 find_package(fmt)
 
 find_package(nlohmann_json


### PR DESCRIPTION
express-cpp breaks at this line when host have boost version 1.71. Thats why, removing the line can be helpful in breaking the software